### PR TITLE
Don't write SCKDIV when flashing

### DIFF
--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -1032,10 +1032,6 @@ static int fespi_probe(struct flash_bank *bank)
 			target_device->name, bank->base);
 
 	/* read and decode flash ID; returns in SW mode */
-	// TODO!!! Pass these arguments in to the driver
-	// Elsewhere this driver assumes these are set this way,
-	// but should really save and restore at the entry points.
-	FESPI_WRITE_REG(FESPI_REG_SCKDIV, 3);
 	FESPI_WRITE_REG(FESPI_REG_TXCTRL, FESPI_TXWM(1));
 	fespi_set_dir(bank, FESPI_DIR_TX);
 


### PR DESCRIPTION
The target may have already configured its clock to run at a higher frequency and would have set SCKDIV and other dividers at that time. Don't restore the SCKDIV to its default or the flash interface may run too fast and programming will fail.

Otherwise, the default value is fine and there is no need to write SCKDIV.