### PR TITLE
Use portable format specifier for size_t

### DIFF
--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -835,7 +835,7 @@ static int fespi_write(struct flash_bank *bank, const uint8_t *buffer,
 	struct working_area *algorithm_wa;
 	if (target_alloc_working_area(target, sizeof(algorithm_bin),
 				&algorithm_wa) != ERROR_OK) {
-		LOG_WARNING("Couldn't allocate %ld-byte working area.",
+		LOG_WARNING("Couldn't allocate %zd-byte working area.",
 				sizeof(algorithm_bin));
 		algorithm_wa = NULL;
 	} else {


### PR DESCRIPTION
This fixes the following warning (turned fatal with `-Werror`) on i686-pc-linux-gnu:
```
fespi.c: In function 'fespi_write':
fespi.c:838:3: error: format '%ld' expects argument of type 'long int', but argument 6 has type 'unsigned int' [-Werror=format=]
   LOG_WARNING("Couldn't allocate %ld-byte working area.",
   ^
cc1: all warnings being treated as errors
```