### PR TITLE
riscv: Increase the number of Algorithm Steps

### DIFF
--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -877,7 +877,7 @@ static int fespi_write(struct flash_bank *bank, const uint8_t *buffer,
 	if (retval != ERROR_OK)
 		return retval;
 
-	struct algorithm_steps *as = as_new(count / 16);
+	struct algorithm_steps *as = as_new(count / 4);
 
 	/* unaligned buffer head */
 	if (count > 0 && (offset & 3) != 0) {


### PR DESCRIPTION
I kept getting assertion failures that I was adding more steps than I had allocated for. I wasn't sure where the "/16" came from in your code... "/4" made more sense to me if you're writing one word at a time but not sure.

This fixes my immediate issue but not sure it's the correct fix.