### PR TITLE
Correct off by 1 in malloc

### DIFF
--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -676,7 +676,7 @@ void as_add_tx(struct algorithm_steps *as, unsigned count, const uint8_t *data)
 	while (count > 0) {
 		unsigned step_count = MIN(count, 255);
 		assert(as->used < as->size);
-		as->steps[as->used] = malloc(step_count + 1);
+		as->steps[as->used] = malloc(step_count + 2);
 		as->steps[as->used][0] = STEP_TX;
 		as->steps[as->used][1] = step_count;
 		memcpy(as->steps[as->used] + 2, data, step_count);


### PR DESCRIPTION
which causes this to fail on macOS (and in theory on any platform).

This manifests itself as corrupted data while Flashing