### PR TITLE
riscv: Globally disable interrupts when running algorithms.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2704,10 +2704,10 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 	LOG_DEBUG("Disabling Interrupts");
 	register_get(&target->reg_cache->reg_list[REG_MSTATUS]);
 	current_mstatus = buf_get_u64(target->reg_cache->reg_list[REG_MSTATUS].value, 0, info->xlen);
-	buf_set_u64(mstatus_bytes, 0, info->xlen, (current_mstatus & (~((uint64_t)MSTATUS_MIE))) );
+	uint64_t ie_mask = MSTATUS_MIE | MSTATUS_HIE | MSTATUS_SIE | MSTATUS_UIE;
+	buf_set_u64(mstatus_bytes, 0, info->xlen, set_field(current_mstatus, ie_mask, 0));
 
 	register_set(&target->reg_cache->reg_list[REG_MSTATUS], mstatus_bytes);
-	info->mstatus_actual = current_mstatus & ~MSTATUS_MIE;
 
 	/// Run algorithm
 	LOG_DEBUG("resume at 0x%x", entry_point);
@@ -2746,7 +2746,6 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 	LOG_DEBUG("Restoring Interrupts");
 	buf_set_u64(mstatus_bytes, 0, info->xlen, current_mstatus);
 	register_set(&target->reg_cache->reg_list[REG_MSTATUS], mstatus_bytes);
-	info->mstatus_actual = current_mstatus;
 
 	/// Restore registers
 	uint8_t buf[8];

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2696,6 +2696,18 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 		}
 	}
 
+
+	// Disable Interrupts before attempting to run the algorithm.
+	// Is it possible/desirable to do this in the calling code instead?
+	uint64_t current_mstatus;
+
+	register_get(&target->reg_cache->reg_list[REG_MSTATUS]);
+	current_mstatus = info->mstatus_actual;
+	current_mstatus = current_mstatus & ~((uint64_t) 0x8);
+	register_set((&target->reg_cache->reg_list[REG_MSTATUS]), (uint8_t*) &current_mstatus);
+	info->mstatus_actual = current_mstatus;
+
+
 	/// Run algorithm
 	LOG_DEBUG("resume at 0x%x", entry_point);
 	if (riscv_resume(target, 0, entry_point, 0, 0) != ERROR_OK) {


### PR DESCRIPTION
This works for flashing the SPI Flash when the running program has interrupts. I don't restore interrupts afterwards, but our SPI flashing code is completely trashing the program space anyway as it is now.

However, not sure this is the most general solution.

 Does it make more sense to disable and re-enable interrupts at a higher level? Like, can the fespi SPI Flashing code write the CSR somehow (I couldn't figure out how I can do something like "target_write_csr" from that code). Then it could re-enable interrupts after the code has been fully flashed.
