### PR TITLE
Use the set/reg register error return code when registers don't exist.

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -1163,8 +1163,15 @@ static int gdb_get_registers_packet(struct connection *connection,
 	reg_packet_p = reg_packet;
 
 	for (i = 0; i < reg_list_size; i++) {
-		if (!reg_list[i]->valid)
-			reg_list[i]->type->get(reg_list[i]);
+		if (!reg_list[i]->valid) {
+			retval = reg_list[i]->type->get(reg_list[i]);
+			if (retval != ERROR_OK) {
+				LOG_DEBUG("Couldn't get register.");
+				free(reg_packet);
+				free(reg_list);
+				return gdb_error(connection, retval);
+			}
+		}
 		gdb_str_to_target(target, reg_packet_p, reg_list[i]);
 		reg_packet_p += DIV_ROUND_UP(reg_list[i]->size, 8) * 2;
 	}
@@ -1225,7 +1232,13 @@ static int gdb_set_registers_packet(struct connection *connection,
 		bin_buf = malloc(DIV_ROUND_UP(reg_list[i]->size, 8));
 		gdb_target_to_reg(target, packet_p, chars, bin_buf);
 
-		reg_list[i]->type->set(reg_list[i], bin_buf);
+		retval = reg_list[i]->type->set(reg_list[i], bin_buf);
+		if (retval != ERROR_OK) {
+			LOG_DEBUG("Couldn't set register.");
+			free(reg_list);
+			free(bin_buf);
+			return gdb_error(connection, retval);
+		}
 
 		/* advance packet pointer */
 		packet_p += chars;
@@ -1265,8 +1278,14 @@ static int gdb_get_register_packet(struct connection *connection,
 		return ERROR_SERVER_REMOTE_CLOSED;
 	}
 
-	if (!reg_list[reg_num]->valid)
-		reg_list[reg_num]->type->get(reg_list[reg_num]);
+	if (!reg_list[reg_num]->valid) {
+	        retval = reg_list[reg_num]->type->get(reg_list[reg_num]);
+		if (retval != ERROR_OK) {
+			LOG_DEBUG("Couldn't get register.");
+			free (reg_list);
+			return gdb_error(connection, retval);
+		}
+	}
 
 	reg_packet = malloc(DIV_ROUND_UP(reg_list[reg_num]->size, 8) * 2 + 1); /* plus one for string termination null */
 
@@ -1320,7 +1339,13 @@ static int gdb_set_register_packet(struct connection *connection,
 
 	gdb_target_to_reg(target, separator + 1, chars, bin_buf);
 
-	reg_list[reg_num]->type->set(reg_list[reg_num], bin_buf);
+	retval = reg_list[reg_num]->type->set(reg_list[reg_num], bin_buf);
+	if (retval != ERROR_OK){
+		LOG_DEBUG("Couldn't set register.");
+		free(bin_buf);
+		free(reg_list);
+		return gdb_error(connection, retval);
+	}
 
 	gdb_put_packet(connection, "OK", 2);
 

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -1166,7 +1166,7 @@ static int gdb_get_registers_packet(struct connection *connection,
 		if (!reg_list[i]->valid) {
 			retval = reg_list[i]->type->get(reg_list[i]);
 			if (retval != ERROR_OK) {
-				LOG_DEBUG("Couldn't get register.");
+				LOG_DEBUG("Couldn't get register %s.", reg_list[i]->name);
 				free(reg_packet);
 				free(reg_list);
 				return gdb_error(connection, retval);
@@ -1234,7 +1234,7 @@ static int gdb_set_registers_packet(struct connection *connection,
 
 		retval = reg_list[i]->type->set(reg_list[i], bin_buf);
 		if (retval != ERROR_OK) {
-			LOG_DEBUG("Couldn't set register.");
+			LOG_DEBUG("Couldn't set register %s.", reg_list[i]->name);
 			free(reg_list);
 			free(bin_buf);
 			return gdb_error(connection, retval);
@@ -1281,7 +1281,7 @@ static int gdb_get_register_packet(struct connection *connection,
 	if (!reg_list[reg_num]->valid) {
 	        retval = reg_list[reg_num]->type->get(reg_list[reg_num]);
 		if (retval != ERROR_OK) {
-			LOG_DEBUG("Couldn't get register.");
+			LOG_DEBUG("Couldn't get register %s.", reg_list[reg_num]->name);
 			free (reg_list);
 			return gdb_error(connection, retval);
 		}
@@ -1341,7 +1341,7 @@ static int gdb_set_register_packet(struct connection *connection,
 
 	retval = reg_list[reg_num]->type->set(reg_list[reg_num], bin_buf);
 	if (retval != ERROR_OK){
-		LOG_DEBUG("Couldn't set register.");
+		LOG_DEBUG("Couldn't set register %s.", reg_list[reg_num]->name);
 		free(bin_buf);
 		free(reg_list);
 		return gdb_error(connection, retval);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -2703,8 +2703,8 @@ COMMAND_HANDLER(handle_reg_command)
 		if (reg->valid == 0) {
 			retval = reg->type->get(reg);
 			if (retval != ERROR_OK) {
-				LOG_DEBUG("Couldn't get register.");
-				return retval;
+			    LOG_DEBUG("Couldn't get register %s.", reg->name);
+			    return retval;
 			}
 		}
 		value = buf_to_str(reg->value, reg->size, 16);
@@ -2722,7 +2722,7 @@ COMMAND_HANDLER(handle_reg_command)
 
 		retval = reg->type->set(reg, buf);
 		if (retval != ERROR_OK) {
-			LOG_DEBUG("Couldn't set register.");
+		        LOG_DEBUG("Couldn't set register %s.", reg->name);
 			free (buf);
 			return retval;
 		}


### PR DESCRIPTION
This is a change in the base OpenOCD code. The RISC-V code returns an error if an exception is encountered when a register is accessed that doesn't exist (which is fairly common possibility in RISC-V). But, that error code is not checked by OpenOCD and is not communicated to GDB.

I'm not sure if this was an intentional omission from OpenOCD.

