### PR TITLE
V13 reset

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1817,12 +1817,18 @@ static int riscv013_resume(struct target *target, int current, uint32_t address,
 
 static int assert_reset(struct target *target)
 {
-	return ERROR_FAIL;
+  select_dmi(target);
+  dmi_write(target, DMI_DMCONTROL,
+	    DMI_DMCONTROL_DMACTIVE | DMI_DMCONTROL_NDMRESET);
+  return ERROR_OK;
 }
 
 static int deassert_reset(struct target *target)
 {
-	return ERROR_FAIL;
+  select_dmi(target);
+  dmi_write(target, DMI_DMCONTROL,
+	    DMI_DMCONTROL_DMACTIVE);
+  return ERROR_OK;
 }
 
 static int read_memory(struct target *target, uint32_t address,

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -310,6 +310,7 @@ static int riscv_examine(struct target *target)
 {
 	LOG_DEBUG("riscv_examine()");
 	if (target_was_examined(target)) {
+	  LOG_DEBUG("Target was already examined.\n");
 		return ERROR_OK;
 	}
 
@@ -348,12 +349,14 @@ static int riscv_resume(struct target *target, int current, uint32_t address,
 
 static int riscv_assert_reset(struct target *target)
 {
+  LOG_DEBUG("RISCV ASSERT RESET");
 	struct target_type *tt = get_target_type(target);
 	return tt->assert_reset(target);
 }
 
 static int riscv_deassert_reset(struct target *target)
 {
+  LOG_DEBUG("RISCV DEASSERT RESET");
 	struct target_type *tt = get_target_type(target);
 	return tt->deassert_reset(target);
 }


### PR DESCRIPTION
This enables the 'reset halt' type functionality in OpenOCD for v13. I also had to update FESPI driver because it doesn't always initialize everything when it may have been reset between commands.

Is there a better way to do this constant "if error return error" pattern?